### PR TITLE
use sparse matrices from the start in `circuit_solve`

### DIFF
--- a/liionpack/netlist_utils.py
+++ b/liionpack/netlist_utils.py
@@ -297,9 +297,10 @@ def solve_circuit(netlist):
         if nm[0] in V_elem:
             m += 1
 
-    G = np.zeros([n, n])
-    B = np.zeros([n, m])
-    D = np.zeros([m, m])
+    # Use lil matrices to construct the A array
+    G = sp.sparse.lil_matrix((n, n))
+    B = sp.sparse.lil_matrix((n, m))
+    D = sp.sparse.lil_matrix((m, m))
     i = np.zeros([n, 1])
     e = np.zeros([m, 1])
 
@@ -349,15 +350,16 @@ def solve_circuit(netlist):
             if n2 >= 0:
                 i[n2] = i[n2] + arg3[k1]
 
-    upper = np.hstack((G, B))
-    lower = np.hstack((B.T, D))
-    A = np.vstack((upper, lower))
+    upper = sp.sparse.hstack((G, B))
+    lower = sp.sparse.hstack((B.T, D))
+    A = sp.sparse.vstack((upper, lower))
+    # Convert a to csc sparse format for more efficient solving of the linear system
+    A_csc = sp.sparse.csc_matrix(A)
     z = np.vstack((i, e))
-    Aspr = sp.sparse.csr_matrix(A)
+
     # Scipy
     # X = solve(A, z).flatten()
-    X = sp.sparse.linalg.spsolve(Aspr, z).flatten()
-    
+    X = sp.sparse.linalg.spsolve(A_csc, z).flatten()
     # Pypardiso
     # X = pypardiso.spsolve(Aspr, z).flatten()
     


### PR DESCRIPTION
On my laptop, this speeds up `big_circuit.py` from 8 minutes to 5 minutes. 
It seems like the SPMe solvers scale linearly in the number of cells, but the linear system solve is superlinear. This isn't as good as #34 but seems to help a bit for now