### PR TITLE
Add hiredis conda dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
   - autograd
   - absl-py
   - dask
+  - hiredis
   - pip:
     - pybamm
     - lcapy


### PR DESCRIPTION
In the conda environment, I kept getting a warning about using Redis without the hiredis package. So I added the hiredis package to the list of dependencies in the conda environment file. This seems to fix the warning. I think this is related to the Ray package because I didn't see the warning before Ray was used.