### PR TITLE
Fix the failing CI and docs

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -49,17 +49,17 @@ jobs:
         sudo apt-get install ghostscript
     - name: Install specific version of PyBaMM and liionpack
       run: |
-        pip install wheel
+        python -m pip install wheel
         python -m pip install git+https://github.com/pybamm-team/PyBaMM@develop
     - name: Install dependencies
       run: |
-        pip install wheel
+        python -m pip install wheel
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
         pybamm_install_jax
     - name: Install liionpack for ray
       run: |
-        python setup.py install
+        python -m pip install .
     - name: Run tests and generate coverage report
       run: |
         python -m pip install coverage

--- a/liionpack/sim_utils.py
+++ b/liionpack/sim_utils.py
@@ -34,8 +34,8 @@ def get_initial_stoichiometries(initial_soc, parameter_values):
     V_min = parameter_values.evaluate(param.voltage_low_cut_dimensional)
     V_max = parameter_values.evaluate(param.voltage_high_cut_dimensional)
     try:
-        C_n = parameter_values.evaluate(param.C_n_init)
-        C_p = parameter_values.evaluate(param.C_p_init)
+        C_n = parameter_values.evaluate(param.n.c_init)
+        C_p = parameter_values.evaluate(param.p.c_init)
         n_Li = parameter_values.evaluate(param.n_Li_particles_init)
     except ValueError:
         # The initial concentration is dependent on an input

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 matplotlib
-pybamm
+pybamm>=22.5
 pandas
 plotly
 openpyxl
@@ -13,3 +13,4 @@ networkx
 textwrapper
 dask[complete]
 ray
+protobuf==3.20.*


### PR DESCRIPTION
The CI is failing with an error -
```
File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/ray/__init__.py", line 108, in <module>
    import ray._raylet  # noqa: E402
  File "python/ray/_raylet.pyx", line [115](https://github.com/pybamm-team/liionpack/runs/6735663537?check_suite_focus=true#step:8:116), in init ray._raylet
  File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/ray/exceptions.py", line 7, in <module>
    from ray.core.generated.common_pb2 import RayException, Language, PYTHON
  File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/ray/core/generated/common_pb2.py", line 15, in <module>
    from . import runtime_env_common_pb2 as src_dot_ray_dot_protobuf_dot_runtime__env__common__pb2
  File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/ray/core/generated/runtime_env_common_pb2.py", line 36, in <module>
    _descriptor.FieldDescriptor(
  File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/google/protobuf/descriptor.py", line 560, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

The error originates from a breaking change in the new `protobuf` release which is used by `ray`. `Ray` has fixed this on the development branch but hasn't tagged a new version yet, see' - https://github.com/ray-project/ray/issues/25282.

---

The docs are failing with a weird issue related to `site.py` (here is a thread on this - https://github.com/pypa/virtualenv/issues/737) -
```
Collecting pybamm
  Downloading pybamm-22.4.tar.gz (908 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 908.2/908.2 kB 263.4 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      running egg_info
      creating /tmp/pip-pip-egg-info-7u9fhlpe/pybamm.egg-info
      writing /tmp/pip-pip-egg-info-7u9fhlpe/pybamm.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-pip-egg-info-7u9fhlpe/pybamm.egg-info/dependency_links.txt
      writing entry points to /tmp/pip-pip-egg-info-7u9fhlpe/pybamm.egg-info/entry_points.txt
      writing requirements to /tmp/pip-pip-egg-info-7u9fhlpe/pybamm.egg-info/requires.txt
      writing top-level names to /tmp/pip-pip-egg-info-7u9fhlpe/pybamm.egg-info/top_level.txt
      writing manifest file '/tmp/pip-pip-egg-info-7u9fhlpe/pybamm.egg-info/SOURCES.txt'
      reading manifest file '/tmp/pip-pip-egg-info-7u9fhlpe/pybamm.egg-info/SOURCES.txt'
      adding license file 'LICENSE.txt'
      writing manifest file '/tmp/pip-pip-egg-info-7u9fhlpe/pybamm.egg-info/SOURCES.txt'
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-qcqekzwj/pybamm_df8f00e690954098bc64a5e92bd1d207/setup.py", line 227, in <module>
          path_to_sitepackages = site.getsitepackages()[0]
      AttributeError: module 'site' has no attribute 'getsitepackages'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```
The docs are using `PyBaMM` version `22.4`, which might be an issue? If not then the virtual environment would have to be checked.

---

This PR also changes the old parameter style to the new refactored one!