### PR TITLE
Use float32 for NumPy arrays

### DIFF
--- a/liionpack/solvers.py
+++ b/liionpack/solvers.py
@@ -336,16 +336,16 @@ class GenericManager:
         self.Nvar = len(self.variable_names)
 
         # Storage variables for simulation data
-        self.shm_i_app = np.zeros([self.Nsteps, self.Nspm], dtype=float)
-        self.shm_Ri = np.zeros([self.Nsteps, self.Nspm], dtype=float)
-        self.output = np.zeros([self.Nvar, self.Nsteps, self.Nspm], dtype=float)
+        self.shm_i_app = np.zeros([self.Nsteps, self.Nspm], dtype=np.float32)
+        self.shm_Ri = np.zeros([self.Nsteps, self.Nspm], dtype=np.float32)
+        self.output = np.zeros([self.Nvar, self.Nsteps, self.Nspm], dtype=np.float32)
 
         # Initialize currents in battery models
         self.shm_i_app[0, :] = I_batt * -1
 
         # Step forward in time
-        self.V_terminal = np.zeros(self.Nsteps)
-        self.record_times = np.zeros(self.Nsteps)
+        self.V_terminal = np.zeros(self.Nsteps, dtype=np.float32)
+        self.record_times = np.zeros(self.Nsteps, dtype=np.float32)
 
         self.v_cut_lower = parameter_values["Lower voltage cut-off [V]"]
         self.v_cut_higher = parameter_values["Upper voltage cut-off [V]"]


### PR DESCRIPTION
This request uses `float32` for storing the simulation results in the NumPy arrays. The default type when using `float` is `float64` which takes up twice the memory. Changing to `float32` helps reduce memory usage for large pack simulations that run for many cycles. This should also reduce the amount of storage needed to write the simulation results to file. The figure below compares the memory usage for the current liionpack (v0.3.2) which use the `float` type. The figure was generated from a 32p20s pack configuration running for 80 cycles on a linux machine with 20 CPU cores. Each cycle was a single charge/disharge event and the Casadi manager was used for the simulation.

![Figure_1](https://user-images.githubusercontent.com/6828967/179243426-4c11b36a-880d-4f47-ab65-d430e7e08546.png)

Here is the code used to profile the simulations with the [memory-profiler](https://pypi.org/project/memory-profiler/) package.

```python
"""
Medium size pack with 640 cells in a 32p20s configuration.

Run with memory_profiler and log at intervals of 20 s
$ mprof run --interval 20 --output memprofile.dat pack_32p20s.py

Plot memory_profiler results to a PDF file
$ mprof plot --output memprofile.pdf memprofile.dat
"""

import liionpack as lp
import pybamm
import numpy as np

# Define parameters
Np = 32
Ns = 20
cycles = 80
nproc = 20
manager = 'casadi'

# Generate the netlist
netlist = lp.setup_circuit(Np=Np, Ns=Ns)

# Define additional output variables
output_variables = ['Volume-averaged cell temperature [K]']

# Define a cycling experiment using PyBaMM
experiment = pybamm.Experiment([
    'Charge at 20 A for 30 minutes',
    'Rest for 15 minutes',
    'Discharge at 20 A for 30 minutes',
    'Rest for 30 minutes'] * cycles,
    period='30 seconds')

# Define the PyBaMM parameters
chemistry = pybamm.parameter_sets.Chen2020
parameter_values = pybamm.ParameterValues(chemistry=chemistry)
inputs = {"Total heat transfer coefficient [W.m-2.K-1]": np.ones(Np * Ns) * 10}

# Solve the pack
output = lp.solve(netlist=netlist,
                  sim_func=lp.thermal_simulation,
                  parameter_values=parameter_values,
                  experiment=experiment,
                  output_variables=output_variables,
                  initial_soc=0.5,
                  inputs=inputs,
                  nproc=nproc,
                  manager=manager)
```