### PR TITLE
Use pypa/gh-action-pypi-publish@release/v1

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Publish on PyPI
         if: github.event.inputs.target == 'pypi'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Publish on TestPyPI
         if: github.event.inputs.target == 'testpypi'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_TOKEN }}


### PR DESCRIPTION
See https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-

---

## 🌇 `master` branch sunset ❗

The `master` branch version has been sunset. Please, change the GitHub Action version you use from `master` to `release/v1` or use an exact tag, or a full Git commit SHA.

---