### PR TITLE
Model Events & Model Names Haulting Code Execution

### DIFF
--- a/liionpack/solvers.py
+++ b/liionpack/solvers.py
@@ -521,12 +521,15 @@ class CasadiManager(GenericManager):
         Nr, Nc = event_change.shape
         event_names = self.actors[0].get_event_names()
         for r in range(Nr):
-            if np.any(event_change[r, :]):
-                lp.logger.warning(
-                    event_names[r]
-                    + ", Batteries: "
-                    + str(np.where(event_change[r, :])[0].tolist())
-                )
+            try:
+                if np.any(event_change[r, :]):
+                    lp.logger.warning(
+                        event_names[r]
+                        + ", Batteries: "
+                        + str(np.where(event_change[r, :])[0].tolist())
+                    )
+            except Exception as e:
+                lp.logger.warning("Event logging failed: " + str(e))
 
     def cleanup(self):
         pass


### PR DESCRIPTION
I am creating this PR to try and fix the issue I was having when liionpack detected cells hitting the voltage cutoff. This happens when I am using JellyBaMM to run simulations, where the thermal_external simulation type is used.

The model events and model events names have a different length leading to the error described in issue #282. 

The commit I have already added is just in place to prevent the code execution from haulting, but is not a fix to prevent the issue from occuring.